### PR TITLE
Use Java config to use environment variables for DB connection

### DIFF
--- a/src/main/java/com/revature/caliber/config/CaliberSpringDataConfig.java
+++ b/src/main/java/com/revature/caliber/config/CaliberSpringDataConfig.java
@@ -1,0 +1,22 @@
+package com.revature.caliber.config;
+
+import javax.sql.DataSource;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import oracle.jdbc.pool.OracleDataSource;
+
+@Configuration
+public class CaliberSpringDataConfig {
+	@Bean
+	public DataSource dataSource() throws Exception {
+		OracleDataSource ods = new OracleDataSource();
+		
+		ods.setUser(System.getenv("CALIBER_DB_USER"));
+		ods.setPassword(System.getenv("CALIBER_DB_PASS"));
+		ods.setURL(System.getenv("CALIBER_DB_URL"));
+		ods.setDriverType("oracle.jdbc.driver.OracleDriver");
+		return ods;
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
-spring.datasource.username=caliber
-spring.datasource.password=p4ssw0rd
-spring.datasource.url=jdbc:oracle:thin:@localhost:1521:xe
-spring.datasource.driver-class-name=oracle.jdbc.driver.OracleDriver
+#spring.datasource.username=caliber
+#spring.datasource.password=p4ssw0rd
+#spring.datasource.url=jdbc:oracle:thin:@localhost:1521:xe
+#spring.datasource.driver-class-name=oracle.jdbc.driver.OracleDriver
 
 spring.jpa.database-platform=org.hibernate.dialect.Oracle10gDialect


### PR DESCRIPTION
Use Java config to get environment variables to set up the DB connection instead of using application.properties.